### PR TITLE
Fixed main panel height limit bug

### DIFF
--- a/src/client/slots/workbench/index.tsx
+++ b/src/client/slots/workbench/index.tsx
@@ -50,7 +50,7 @@ export default function Workbench({ onSideChange, onEditorChange }: IWorkbenchPr
                             split="horizontal"
                             onChange={editorChange(onEditorChange)}
                         >
-                            <Split.Pane minSize={150} maxSize={300}>
+                            <Split.Pane minSize={150}>
                                 {Editor}
                             </Split.Pane>
                             <Split.Pane hidden={layout.panel.hidden}>{Panel}</Split.Pane>


### PR DESCRIPTION
if you drag splitter abrove output window, the main panel would trigger maxSize limit, and couldn't change it's size.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Changes

Please describe the changes, help the reviewer to read your code.

-   Change A
-   Change B

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

-   [ ] Test A
-   [ ] Test B

## Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
