### PR TITLE
disable panel content selectable when dragging splitters

### DIFF
--- a/src/client/components/split/splitPane/index.tsx
+++ b/src/client/components/split/splitPane/index.tsx
@@ -170,6 +170,7 @@ export const SplitPane = forwardRef<HTMLDivElement, ISplitProps>(function (
                     if (resizing()) {
                         paneStyle.pointerEvents = 'none';
                         paneStyle.transition = 'none';
+						paneStyle.userSelect = 'none';
                     }
 
                     let sashChild: ReactNode = null;


### PR DESCRIPTION
When dragging the splitter, it is easy to trigger the selection event of text content (in editor, menu label, etc.), set user-select to 'none' in panel style to disable this event

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Changes

Please describe the changes, help the reviewer to read your code.

-   Change A
-   Change B

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

-   [ ] Test A
-   [ ] Test B

## Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
